### PR TITLE
Add function requires() to handle luatex

### DIFF
--- a/citeproc/citeproc-engine.lua
+++ b/citeproc/citeproc-engine.lua
@@ -6,35 +6,23 @@
 
 local engine = {}
 
-local dom
-local context
-local element
-local nodes
-local node_locale
-local node_style
-local output
-local util
-
-local using_luatex, _ = pcall(require, "kpse")
-if using_luatex then
-  dom = require("luaxml-domobject")
-  context = require("citeproc-context")
-  element = require("citeproc-element")
-  nodes = require("citeproc-nodes")
-  node_locale = require("citeproc-node-locale")
-  node_style = require("citeproc-node-style")
-  output = require("citeproc-output")
-  util = require("citeproc-util")
-else
-  dom = require("citeproc.luaxml.domobject")
-  context = require("citeproc.context")
-  element = require("citeproc.element")
-  nodes = require("citeproc.nodes")
-  node_locale = require("citeproc.node-locale")
-  node_style = require("citeproc.node-style")
-  output = require("citeproc.output")
-  util = require("citeproc.util")
+local function requires(modname)
+    for _, modname in ipairs{modname, modname:gsub("%.", "-"), "citeproc." .. modname} do
+      local is_ok, mod = pcall(require, modname)
+      if is_ok then
+        return mod
+      end
+    end
 end
+
+local dom = requires("luaxml.domobject")
+local context = requires("citeproc.context")
+local element = requires("citeproc.element")
+local nodes = requires("citeproc.nodes")
+local node_locale = requires("citeproc.node-locale")
+local node_style = requires("citeproc.node-style")
+local output = requires("citeproc.output")
+local util = requires("citeproc.util")
 
 local Element = element.Element
 local Style = node_style.Style

--- a/citeproc/citeproc-node-sort.lua
+++ b/citeproc/citeproc-node-sort.lua
@@ -6,33 +6,22 @@
 
 local sort = {}
 
-local uca_languages
-local uca_ducet
-local uca_collator
-
-local element
-local output
-local util
-local node_date
-
-local using_luatex, kpse = pcall(require, "kpse")
-if using_luatex then
-  uca_languages = require("lua-uca-languages")
-  uca_ducet = require("lua-uca-ducet")
-  uca_collator = require("lua-uca-collator")
-  element = require("citeproc-element")
-  output = require("citeproc-output")
-  util = require("citeproc-util")
-  node_date = require("citeproc-node-date")
-else
-  uca_languages = require("citeproc.lua-uca.languages")
-  uca_ducet = require("citeproc.lua-uca.ducet")
-  uca_collator = require("citeproc.lua-uca.collator")
-  element = require("citeproc.element")
-  output = require("citeproc.output")
-  util = require("citeproc.util")
-  node_date = require("citeproc.node-date")
+local function requires(modname)
+    for _, modname in ipairs{modname, modname:gsub("%.", "-"), "citeproc." .. modname} do
+      local is_ok, mod = pcall(require, modname)
+      if is_ok then
+        return mod
+      end
+    end
 end
+
+local uca_languages = requires("lua-uca.languages")
+local uca_ducet = requires("lua-uca.ducet")
+local uca_collator = requires("lua-uca.collator")
+local element = requires("citeproc.element")
+local output = requires("citeproc.output")
+local util = requires("citeproc.util")
+local node_date = requires("citeproc.node-date")
 
 local Element = element.Element
 local Date = node_date.Date

--- a/citeproc/citeproc-node-style.lua
+++ b/citeproc/citeproc-node-style.lua
@@ -6,23 +6,19 @@
 
 local style_module = {}
 
-local dom
-local element
-local node_names
-local util
-
-local using_luatex, kpse = pcall(require, "kpse")
-if using_luatex then
-  dom = require("luaxml-domobject")
-  element = require("citeproc-element")
-  node_names = require("citeproc-node-names")
-  util = require("citeproc-util")
-else
-  dom = require("citeproc.luaxml.domobject")
-  element = require("citeproc.element")
-  node_names = require("citeproc.node-names")
-  util = require("citeproc.util")
+local function requires(modname)
+    for _, modname in ipairs{modname, modname:gsub("%.", "-"), "citeproc." .. modname} do
+      local is_ok, mod = pcall(require, modname)
+      if is_ok then
+        return mod
+      end
+    end
 end
+
+local dom = requires("luaxml.domobject")
+local element = requires("citeproc.element")
+local node_names = requires("citeproc.node-names")
+local util = requires("citeproc.util")
 
 local Element = element.Element
 


### PR DESCRIPTION
Original code based on using_luatex is too ugly.

We can add a function requires() to handle the different module names.

This is a demo. If you support it. more PRs will use function requires() to rewrite.
